### PR TITLE
ci: use included prebuilt binaries in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,26 +30,6 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Try getting flatc from cache
-        uses: actions/cache@v3
-        id: cache-flatc
-        with:
-          path: ~/.local/bin
-          key: ${{ runner.os }}-build-flatc-clang12-23-1-21
-
-      - name: Fetch latest flatc release
-        if: steps.cache-flatc.outputs.cache-hit != 'true'
-        uses: dsaltares/fetch-gh-release-asset@master
-        with:
-          repo: google/flatbuffers
-          version: tags/v23.1.21
-          file: Linux.flatc.binary.clang++-12.zip
-          target: flatc/flatc-zipped.zip
-
-      - name: Unzip fetched release
-        if: steps.cache-flatc.outputs.cache-hit != 'true'
-        run: unzip flatc/flatc-zipped.zip -d ~/.local/bin
-
       - name: cargo check
         run: cargo check
 
@@ -92,26 +72,6 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Try getting flatc from cache
-        uses: actions/cache@v3
-        id: cache-flatc
-        with:
-          path: ~/.local/bin
-          key: ${{ runner.os }}-build-flatc-clang12-23-1-21
-
-      - name: Fetch latest flatc release
-        if: steps.cache-flatc.outputs.cache-hit != 'true'
-        uses: dsaltares/fetch-gh-release-asset@master
-        with:
-          repo: google/flatbuffers
-          version: tags/v23.1.21
-          file: Linux.flatc.binary.clang++-12.zip
-          target: flatc/flatc-zipped.zip
-
-      - name: Unzip fetched release
-        if: steps.cache-flatc.outputs.cache-hit != 'true'
-        run: unzip flatc/flatc-zipped.zip -d ~/.local/bin
-
       - name: cargo clippy --all-features -- -D warnings
         run: cargo clippy --all-features -- -D warnings
 
@@ -130,26 +90,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
-
-      - name: Try getting flatc from cache
-        uses: actions/cache@v3
-        id: cache-flatc
-        with:
-          path: ~/.local/bin
-          key: ${{ runner.os }}-build-flatc-clang12-23-1-21
-
-      - name: Fetch latest flatc release
-        if: steps.cache-flatc.outputs.cache-hit != 'true'
-        uses: dsaltares/fetch-gh-release-asset@master
-        with:
-          repo: google/flatbuffers
-          version: tags/v23.1.21
-          file: Linux.flatc.binary.clang++-12.zip
-          target: flatc/flatc-zipped.zip
-
-      - name: Unzip fetched release
-        if: steps.cache-flatc.outputs.cache-hit != 'true'
-        run: unzip flatc/flatc-zipped.zip -d ~/.local/bin
 
       - name: cargo test
         run: cargo test
@@ -174,26 +114,6 @@ jobs:
           components: rust-docs
 
       - uses: Swatinem/rust-cache@v2
-
-      - name: Try getting flatc from cache
-        uses: actions/cache@v3
-        id: cache-flatc
-        with:
-          path: ~/.local/bin
-          key: ${{ runner.os }}-build-flatc-clang12-23-1-21
-
-      - name: Fetch latest flatc release
-        if: steps.cache-flatc.outputs.cache-hit != 'true'
-        uses: dsaltares/fetch-gh-release-asset@master
-        with:
-          repo: google/flatbuffers
-          version: tags/v23.1.21
-          file: Linux.flatc.binary.clang++-12.zip
-          target: flatc/flatc-zipped.zip
-
-      - name: Unzip fetched release
-        if: steps.cache-flatc.outputs.cache-hit != 'true'
-        run: unzip flatc/flatc-zipped.zip -d ~/.local/bin
 
       - name: cargo doc --no-deps
         run: cargo doc --no-deps

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,26 +28,6 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Try getting flatc from cache
-        uses: actions/cache@v3
-        id: cache-flatc
-        with:
-          path: ~/.local/bin
-          key: ${{ runner.os }}-build-flatc-clang12-23-1-21
-
-      - name: Fetch latest flatc release
-        if: steps.cache-flatc.outputs.cache-hit != 'true'
-        uses: dsaltares/fetch-gh-release-asset@master
-        with:
-          repo: google/flatbuffers
-          version: tags/v23.1.21
-          file: Linux.flatc.binary.clang++-12.zip
-          target: flatc/flatc-zipped.zip
-
-      - name: Unzip fetched release
-        if: steps.cache-flatc.outputs.cache-hit != 'true'
-        run: unzip flatc/flatc-zipped.zip -d ~/.local/bin
-
       - name: cargo publish
         shell: bash
         run: cargo publish --token ${{ secrets.CRATES_TOKEN }}


### PR DESCRIPTION
<!-- Thank you for your pull request. Make sure you read the contributing guidelines in
CONTRIBUTING.md -->
## Description
Uses the new binaries from the previous PR to build the crate during CI and publish workflows.

## Motivation
We have those binaries for a reason, so might as well use them. Also cleans up CI workflows somewhat. 