### PR TITLE
ci: remove references of RMAN_SCHEMA_PAT secret

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,4 @@
-<!-- Thank you for your pull request. Make sure you read the contributing guidelines in
-CONTRIBUTING.md -->
+<!-- Thank you for your pull request. Make sure you read the contributing guidelines in CONTRIBUTING.md -->
 ## Description
 <!-- Describe what you changed, along with the related issue (if applicable). -->
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.RMAN_SCHEMA_PAT }}
           submodules: true
 
       - name: Install rust
@@ -41,7 +40,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.RMAN_SCHEMA_PAT }}
           submodules: true
 
       - name: Install rust
@@ -62,7 +60,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.RMAN_SCHEMA_PAT }}
           submodules: true
 
       - name: Install rust
@@ -83,7 +80,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.RMAN_SCHEMA_PAT }}
           submodules: true
 
       - name: Install rust
@@ -105,7 +101,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.RMAN_SCHEMA_PAT }}
           submodules: true
 
       - name: Install rust

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.RMAN_SCHEMA_PAT }}
           submodules: true
 
       - name: Install rust


### PR DESCRIPTION
## Description
Removes all of the references to `RMAN_SCHEMA_PAT` secret, which is no longer required.

## Motivation
`rman-schema` is no longer private so personal access token is no longer needed to clone it.