### PR TITLE
feat!: add optional `flatbuffer_verifier_options` parameter to methods

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -87,7 +87,8 @@ impl File {
 
         while directory_id != 0 {
             let Some((dir_name, parent_id)) = directories.get(&directory_id) else {
-                let message = format!("could not find a directory with the following id: \"{directory_id}\"");
+                let message =
+                    format!("could not find a directory with the following id: \"{directory_id}\"");
                 return Err(ManifestError::FileParseError(message));
             };
             path = format!("{dir_name}/{path}");
@@ -112,7 +113,8 @@ impl File {
 
         for chunk_id in chunk_ids {
             let Some(chunk) = chunk_entries.get(chunk_id) else {
-                let message = format!("could not find a chunk with the following id: \"{chunk_id}\"");
+                let message =
+                    format!("could not find a chunk with the following id: \"{chunk_id}\"");
                 return Err(ManifestError::FileParseError(message));
             };
             chunks.push(chunk.to_owned());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 //! let path = "file.manifest";
 //!   # let path = concat!(env!("OUT_DIR"), "/valid.manifest");
 //!
-//! let manifest = RiotManifest::from_path(path)?;
+//! let manifest = RiotManifest::from_path(path, None)?;
 //!
 //! assert_eq!(manifest.data.files.len(), 1);
 //!   # Ok(())
@@ -66,7 +66,7 @@
 //! let file = fs::File::open(path)?;
 //! let mut reader = BufReader::new(file);
 //!
-//! let manifest = RiotManifest::from_reader(&mut reader)?;
+//! let manifest = RiotManifest::from_reader(&mut reader, None)?;
 //!
 //! assert_eq!(manifest.data.files.len(), 1);
 //!   # Ok(())
@@ -102,7 +102,7 @@
 //!     # );
 //!     let path = "file.manifest";
 //!     # let path = concat!(env!("OUT_DIR"), "/valid.manifest");
-//!     let manifest = RiotManifest::from_path(path)?;
+//!     let manifest = RiotManifest::from_path(path, None)?;
 //!
 //!     let file_name = "VALORANT.exe";
 //!     # let file_name = "file.txt";

--- a/src/parser/manifest.rs
+++ b/src/parser/manifest.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::entries::{
     BundleEntry, ChunkingParamEntry, DirectoryEntry, FileEntry, KeyEntry, TagEntry,
 };
-use crate::generated::rman::root_as_manifest;
+use crate::generated::rman::root_as_manifest_with_opts;
 use crate::File;
 use crate::Result;
 
@@ -54,8 +54,16 @@ impl ManifestData {
     ///
     /// If parsing the [`File`][crate::File] fails, it propagates an error from
     /// [`File::parse`][crate::File::parse].
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
-        let manifest = root_as_manifest(bytes)?;
+    pub fn parse(
+        bytes: &[u8],
+        flatbuffer_verifier_options: Option<&flatbuffers::VerifierOptions>,
+    ) -> Result<Self> {
+        let opts = flatbuffers::VerifierOptions {
+            max_tables: 10_000_000,
+            ..Default::default()
+        };
+        let manifest =
+            root_as_manifest_with_opts(flatbuffer_verifier_options.unwrap_or(&opts), bytes)?;
 
         let bundle_entries: Vec<_> = map_vector!(manifest, bundles, BundleEntry);
         let directory_entries: Vec<_> = map_vector!(manifest, directories, DirectoryEntry);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3,7 +3,7 @@ use rman::RiotManifest;
 #[test]
 pub fn should_parse_from_path_when_valid_manifest() {
     let path = concat!(env!("OUT_DIR"), "/valid.manifest");
-    if let Err(error) = RiotManifest::from_path(path) {
+    if let Err(error) = RiotManifest::from_path(path, None) {
         panic!(
             "there was an error when trying to parse the manifest, manifest: {:?}",
             error
@@ -14,7 +14,7 @@ pub fn should_parse_from_path_when_valid_manifest() {
 #[test]
 pub fn should_have_correct_values_when_valid_manifest() {
     let path = concat!(env!("OUT_DIR"), "/valid.manifest");
-    let manifest = RiotManifest::from_path(path).unwrap();
+    let manifest = RiotManifest::from_path(path, None).unwrap();
 
     // TODO: header value comparsion should also be done
     assert_eq!(
@@ -58,7 +58,7 @@ pub fn should_have_correct_values_when_valid_manifest() {
 #[test]
 pub fn should_parse_from_path_when_valid_empty_manifest() {
     let path = concat!(env!("OUT_DIR"), "/valid_empty.manifest");
-    if let Err(error) = RiotManifest::from_path(path) {
+    if let Err(error) = RiotManifest::from_path(path, None) {
         panic!(
             "there was an error when trying to parse the manifest, manifest: {:?}",
             error
@@ -69,7 +69,7 @@ pub fn should_parse_from_path_when_valid_empty_manifest() {
 #[test]
 pub fn should_have_correct_values_when_valid_empty_manifest() {
     let path = concat!(env!("OUT_DIR"), "/valid_empty.manifest");
-    let manifest = RiotManifest::from_path(path).unwrap();
+    let manifest = RiotManifest::from_path(path, None).unwrap();
 
     // TODO: header value comparsion should also be done
     assert_eq!(


### PR DESCRIPTION
## Description
Added an optional `flatbuffer_verifier_options` parameter of type `Option<&flatbuffers::VerifierOptions>` to `RiotManifest::from_path`, `RiotManifest::from_reader` and `ManifestData::parse`. If set to `None`, it defaults to `max_tables`: `10_000_000` + defaults.

## Motivation
Latest riot manifest [`00AFF46430CFBC0C`](https://valorant.secure.dyn.riotcdn.net/channels/public/releases/00AFF46430CFBC0C.manifest) doesn't parse with the `FlatbufferError(TooManyTables)` error. 